### PR TITLE
Add detailed project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
 # paduch.dev
+
+Este repositório contém o código fonte do meu portfólio pessoal. O site foi construído em React + TypeScript utilizando Vite para o build e Tailwind CSS para estilização.
+
+## Sobre o Projeto
+
+O objetivo é apresentar de forma objetiva minhas principais habilidades, projetos e depoimentos de clientes. O aplicativo é dividido em seções que podem ser acessadas através do menu de navegação:
+
+- **Hero** – apresenta um resumo sobre minhas áreas de atuação e um link para download do CV.
+- **Sobre** – traz informações gerais e uma lista de skills técnicas agrupadas por categoria.
+- **Projetos** – mostra alguns trabalhos relevantes, exibindo descrição, tecnologias utilizadas e links.
+- **Depoimentos** – feedback de clientes sobre as soluções entregues.
+- **Contato** – informações para entrar em contato e formulário para envio de mensagens.
+
+Os textos e listas exibidos nessas seções estão em `src/data` e podem ser facilmente alterados.
+
+## Tecnologias Principais
+
+- [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/)
+- [Vite](https://vitejs.dev/) para desenvolvimento e build
+- [Tailwind CSS](https://tailwindcss.com/) para estilização
+- [Lucide](https://lucide.dev/) para ícones
+
+## Estrutura de Pastas
+
+```
+src/
+├── components/   # componentes React reutilizáveis
+├── data/         # listas de projetos, skills e depoimentos
+├── types/        # definições TypeScript compartilhadas
+├── index.css     # estilos globais e utilidades do Tailwind
+├── main.tsx      # ponto de entrada da aplicação
+└── App.tsx       # layout principal
+```
+
+## Comandos
+
+Instale as dependências e rode o projeto em modo de desenvolvimento:
+
+```bash
+npm install
+npm run dev
+```
+
+Para gerar o build de produção:
+
+```bash
+npm run build
+```
+
+Você também pode verificar o bundle gerado localmente com:
+
+```bash
+npm run preview
+```
+
+Para checar problemas de estilo ou possíveis erros de código:
+
+```bash
+npm run lint
+```
+
+## Configuração
+
+- Os estilos personalizados estão definidos em `tailwind.config.js`.
+- O comportamento do Vite está em `vite.config.ts`.
+- Configurações de lint no arquivo `eslint.config.js`.
+
+## Como Contribuir
+
+Este repositório tem fins de portfólio e não há planos de aceitar contribuições externas. Sinta-se livre para explorar o código e utilizar trechos como referência em seus projetos.
+
+---
+
+Feito com ❤️, código e muito café.

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -12,8 +12,8 @@ const About: React.FC = () => {
           <div className="w-24 h-1 bg-primary-500 mx-auto"></div>
         </div>
 
-        <div className="grid lg:grid-cols-2 gap-16 items-center">
-          <div className="space-y-6">
+        <div className="grid lg:grid-cols-5 gap-16 items-start">
+          <div className="space-y-6 lg:col-span-3">
             <h3 className="text-2xl font-semibold text-white mb-6">Quem sou eu</h3>
             <div className="space-y-4 text-gray-300 text-lg leading-relaxed">
               <p>
@@ -34,9 +34,9 @@ const About: React.FC = () => {
             </div>
           </div>
 
-          <div>
+          <div className="lg:col-span-2">
             <h3 className="text-2xl font-semibold text-white mb-8">Skills Técnicas</h3>
-            <div className="grid gap-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
               {skills.map((skill, index) => (
                 <div 
                   key={skill.category} 


### PR DESCRIPTION
## Summary
- expand README with project overview, setup instructions and tech stack
- revamp the About section layout so the text spans 60% and the skills display in a responsive grid

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*


------
https://chatgpt.com/codex/tasks/task_e_685386a1f374832ba9874dc946dfcaa6